### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Hivy
 ====
 
-[![Latest Version](https://pypip.in/v/hivy/badge.png)](https://pypi.python.org/pypi/hivy/)
+[![Latest Version](https://img.shields.io/pypi/v/hivy.svg)](https://pypi.python.org/pypi/hivy/)
 [![Build Status](https://drone.io/github.com/hivetech/hivy/status.png)](https://drone.io/github.com/hivetech/hivy/latest)
 [![Coverage Status](https://coveralls.io/repos/hivetech/hivy/badge.png)](https://coveralls.io/r/hivetech/hivy)
 [![Code Health](https://landscape.io/github/hivetech/hivy/master/landscape.png)](https://landscape.io/github/hivetech/hivy/master)
 [![Requirements Status](https://requires.io/github/hivetech/hivy/requirements.png?branch=master)](https://requires.io/github/hivetech/hivy/requirements/?branch=master)
-[![License](https://pypip.in/license/hivy/badge.png)](https://pypi.python.org/pypi/hivy/)
+[![License](https://img.shields.io/pypi/l/hivy.svg)](https://pypi.python.org/pypi/hivy/)
 
 > Unide Hive controller
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hivy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hivy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.